### PR TITLE
Fixing issue with prisma on netlify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,38 +1,39 @@
 {
-  "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start"
-  },
-  "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.5.1",
-    "@fortawesome/free-solid-svg-icons": "^6.5.1",
-    "@fortawesome/react-fontawesome": "^0.2.0",
-    "@prisma/client": "^5.9.1",
-    "@supabase/auth-helpers-nextjs": "^0.9.0",
-    "@supabase/auth-helpers-react": "^0.4.2",
-    "@supabase/ssr": "latest",
-    "@supabase/supabase-js": "latest",
-    "autoprefixer": "10.4.17",
-    "geist": "^1.2.1",
-    "graphql": "^16.8.1",
-    "graphql-request": "^6.1.0",
-    "html-react-parser": "^5.1.2",
-    "next": "latest",
-    "next-mdx-remote": "^4.4.1",
-    "postcss": "8.4.33",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "tailwindcss": "3.4.1",
-    "typescript": "5.3.3"
-  },
-  "devDependencies": {
-    "@types/node": "20.11.5",
-    "@types/react": "18.2.48",
-    "@types/react-dom": "18.2.18",
-    "encoding": "^0.1.13",
-    "prisma": "^5.9.1",
-    "sass": "^1.70.0"
-  }
+    "private": true,
+    "scripts": {
+        "dev": "next dev",
+        "build": "prisma generate && next build",
+        "start": "next start",
+        "postinstall": "prisma generate"
+    },
+    "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.5.1",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
+        "@prisma/client": "^5.9.1",
+        "@supabase/auth-helpers-nextjs": "^0.9.0",
+        "@supabase/auth-helpers-react": "^0.4.2",
+        "@supabase/ssr": "latest",
+        "@supabase/supabase-js": "latest",
+        "autoprefixer": "10.4.17",
+        "geist": "^1.2.1",
+        "graphql": "^16.8.1",
+        "graphql-request": "^6.1.0",
+        "html-react-parser": "^5.1.2",
+        "next": "latest",
+        "next-mdx-remote": "^4.4.1",
+        "postcss": "8.4.33",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "tailwindcss": "3.4.1",
+        "typescript": "5.3.3"
+    },
+    "devDependencies": {
+        "@types/node": "20.11.5",
+        "@types/react": "18.2.48",
+        "@types/react-dom": "18.2.18",
+        "encoding": "^0.1.13",
+        "prisma": "^5.9.1",
+        "sass": "^1.70.0"
+    }
 }


### PR DESCRIPTION
Prisma has detected that this project was built on Netlify, which caches dependencies.
This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
To fix this, make sure to run the \`prisma generate\` command during the build process.

Learn how: https://pris.ly/d/netlify-build

https://www.prisma.io/docs/orm/more/help-and-troubleshooting/help-articles/netlify-caching-issue